### PR TITLE
add coupon after cart item added

### DIFF
--- a/woocommerce-coupon-links.php
+++ b/woocommerce-coupon-links.php
@@ -48,4 +48,4 @@ function cedaro_woocommerce_coupon_links() {
 	// Apply the coupon code to the cart.
 	$woocommerce->cart->add_discount( sanitize_text_field( $coupon_code ) );
 }
-add_action( 'woocommerce_cart_loaded_from_session', 'cedaro_woocommerce_coupon_links' );
+add_action( 'wp_loaded', 'cedaro_woocommerce_coupon_links', 30);


### PR DESCRIPTION
When adding both an item and a coupon to the cart at the same time, the coupon was being added first. In my case, my coupon was restricted to the item that hadn't loaded yet, and it failed.

WooCommerce adds items to the cart with the wp_loaded hook, at priority 20.