### PR TITLE
Make sure coupon is not already applied before applying it

### DIFF
--- a/woocommerce-coupon-links.php
+++ b/woocommerce-coupon-links.php
@@ -51,7 +51,9 @@ function cedaro_woocommerce_coupon_links() {
 
 	// Apply the coupon to the cart.
 	// WC_Cart::add_discount() sanitizes the coupon code.
-	WC()->cart->add_discount( $_GET[ $query_var ] );
+	if ( ! WC()->cart->has_discount( $_GET[ $query_var ] ) ) {
+		WC()->cart->add_discount( $_GET[ $query_var ] );
+	}
 }
 add_action( 'wp_loaded', 'cedaro_woocommerce_coupon_links', 30 );
 add_action( 'woocommerce_add_to_cart', 'cedaro_woocommerce_coupon_links' );


### PR DESCRIPTION
I just found this plugin and decided to give it a try. The simplicity is awesome! I noticed, however, when I tried to add a product to the cart and also apply a coupon in the same URL string as suggested in the README, I would get these three notifications on the front end:

1. Coupon code already applied!
2. Coupon code applied successfully.
3. "Example Product" has been added to your cart.

The first message was a warning message. When I looked at the code of this plugin, I noticed that it ran on two different hooks. In this case, both hooks were running on the same request and therefore it would attempt to add the code twice. I just added a simple if statement to verify the code didn't already exist before trying to add it again.