### PR TITLE
Added functionality to show coupon URL on coupon screen

### DIFF
--- a/woocommerce-coupon-links-admin.css
+++ b/woocommerce-coupon-links-admin.css
@@ -1,0 +1,12 @@
+#coupon-url-label {
+	float: left;
+	width: 150px;
+	padding: 0;
+	margin: 0 0 0 -150px;
+	cursor: pointer;
+}
+
+#coupon-url {
+	font-size: 13px;
+	cursor: pointer;
+}

--- a/woocommerce-coupon-links-admin.js
+++ b/woocommerce-coupon-links-admin.js
@@ -1,0 +1,37 @@
+(function( $ ) {
+	'use strict';
+
+	$(function() {
+
+		// 'pagenow' variable exists on admin pages
+		if ( 'shop_coupon' === pagenow ) {
+
+			// When URL or label for URL are clicked, select the URL for easy copying.
+			$( '#coupon-url, #coupon-url-label' ).click( function() {
+				var doc = document, range, selection,
+					text = $( '#coupon-url' )[0];
+
+				if ( doc.body.createTextRange ) {
+					range = document.body.createTextRange();
+					range.moveToElementText( text );
+					range.select();
+				} else if ( window.getSelection ) {
+					selection = window.getSelection();
+					range = document.createRange();
+					range.selectNodeContents( text );
+					selection.removeAllRanges();
+					selection.addRange( range );
+				}
+			});
+
+			// Update the URL as the coupon code is changed.
+			$( '#title' ).keyup( function( e ) {
+				var coupon_url = $( '#coupon-url' ),
+					template = coupon_url.data( 'template' );
+
+				coupon_url.text( template.replace( '{coupon}', e.target.value ) );
+			});
+		}
+	});
+
+})( jQuery );

--- a/woocommerce-coupon-links.php
+++ b/woocommerce-coupon-links.php
@@ -55,5 +55,40 @@ function cedaro_woocommerce_coupon_links() {
 		WC()->cart->add_discount( $_GET[ $query_var ] );
 	}
 }
+
+/*
+ * Display the URL on the coupon page.
+ *
+ * @since 2.0.3
+ */
+function cedaro_show_coupon_url() {
+	// Get the coupon code query variable.
+	$query_var = apply_filters( 'woocommerce_coupon_links_query_var', 'coupon_code' );
+
+	?>
+	<p class="form-field coupon_url_field">
+		<span id="coupon-url-label"><?php esc_html_e( 'Coupon URL', 'cedaro-coupon-links' ); ?></span>
+		<span id="coupon-url" data-template="<?php echo esc_attr( get_home_url() . "?$query_var={coupon}" ); ?>"><?php echo esc_html( get_home_url() . "?$query_var=" . get_the_title() ); ?></span>
+		<span class="woocommerce-help-tip" data-tip="<?php esc_attr_e( 'This field displays the URL that can be used to directly add this coupon. The URL will work in conjunction with other query string parameters. An example of this would be adding a product to the cart while at the same time applying the coupon.', 'cedaro-coupon-links' ); ?>"></span>
+	</p>
+	<?php
+}
+
+/*
+ * Enqueue style and JavaScript needed for proper display of the URL on
+ * the coupon page and also to make it easier to copy the URL.
+ *
+ * @since 2.0.3
+ */
+function cedaro_enqueue_coupon_url_styles() {
+	$screen = get_current_screen();
+
+	if ( ! empty( $screen ) && 'shop_coupon' === $screen->id ) {
+		wp_enqueue_script( 'woocommerce-coupon-links', plugin_dir_url( __FILE__ ) . 'woocommerce-coupon-links-admin.js', array( 'jquery' ), '2.0.3', false );
+		wp_enqueue_style( 'woocommerce-coupon-links', plugin_dir_url( __FILE__ ) . 'woocommerce-coupon-links-admin.css', array(), '2.0.3', 'all' );
+	}
+}
 add_action( 'wp_loaded', 'cedaro_woocommerce_coupon_links', 30 );
 add_action( 'woocommerce_add_to_cart', 'cedaro_woocommerce_coupon_links' );
+add_action( 'woocommerce_coupon_options', 'cedaro_show_coupon_url', 20 );
+add_action( 'admin_enqueue_scripts', 'cedaro_enqueue_coupon_url_styles' );


### PR DESCRIPTION
I've added some functionality to this extension to display a link using the coupon code on a coupon's edit page. It looks something like this:

![image](https://cloud.githubusercontent.com/assets/221971/13625270/d13f3b7c-e583-11e5-8328-910095b2220f.png)

There's a little JavaScript butter in place that automatically selects the text when the label or the URL text is clicked and updates the URL on the fly if the coupon code is changed above.

I realize that adding this stuff does add some complexity to the plugin and I understand if you don't want to merge it into the main plugin. However, I thought I'd offer it up in case you're interested.
